### PR TITLE
Use xacro instead of deprecated xacro.py

### DIFF
--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -17,7 +17,7 @@
     <arg name="headless" value="$(arg headless)"/>
   </include>
 
-  <param name="robot_description" command="$(find xacro)/xacro.py $(arg model)" />
+  <param name="robot_description" command="$(find xacro)/xacro $(arg model)" />
 
   <!-- push robot_description to factory and spawn robot in gazebo -->
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model"


### PR DESCRIPTION
Fixes #7

`xacro.py` is deprecated, and I'm hoping to remove it in ROS Noetic in https://github.com/ros/xacro/pull/239 . This pull request uses `xacro` instead of `xacro.py`.